### PR TITLE
Add GitHub Actions CI/Release workflow and update documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,9 +74,37 @@ All reads and writes go through `RetryHelper.ExecuteWithRetry`, which opens a tr
 
 - **`CachedItem` is immutable.** All modifications create a new instance. Never add mutable setters.
 - **`LinkedDictionaryHelper` is pure.** It returns change sets (`LinkedDictionaryItemsChanged`) without touching the state manager. Keep it that way.
-- **`Shared.targets`** is imported by all NuGet-published `.csproj` files for shared package metadata (author, license, version).
+- **`Directory.Build.props`** holds shared package metadata (author, license, version) and reads `PACKAGE_VERSION` from the environment. Local builds default to `0.0.0-local`.
 - **Tests use `[Theory, AutoMoqData]`** (AutoFixture + AutoMoq). Use `[Frozen]` to inject shared mocks, `[Greedy]` to select the most-parameterised constructor of the SUT. No SF cluster is needed—`IReliableStateManagerReplica2` is mocked.
 - **`StubCacheStoreService`** (inner class in `BaseCacheStoreServiceTest`) is the concrete test double for `BaseCacheStoreService`. Use `[Greedy]` so AutoFixture picks its 4-param ctor `(StatefulServiceContext, IReliableStateManagerReplica2, TimeProvider, ILogger?)`. Call `SetupInMemoryStores` to wire in-memory dictionaries and set the `_cacheStore`/`_cacheStoreMetadata` fields on the stub.
 - **`AutoMoqData` registers `FakeTimeProvider`** as the fixture implementation of `TimeProvider`. Inject `[Frozen] FakeTimeProvider` into tests to control the clock.
 - **SF SDK 8.4+ telemetry**: `StatefulServiceBase..ctor` calls telemetry that reads `ICodePackageActivationContext` string properties. `AutoMoqData` sets these up with non-null stubs; replicate this when building `StatefulServiceContext` outside the fixture.
 - **`ICacheStoreService` extends `IService`** (SF remoting marker interface). Any changes to its method signatures require regenerating the remoting proxy.
+- **Item size accounting**: each item's reported size is `value.Length + ByteSizeOffset`. `ByteSizeOffset` defaults to 250 (configurable via `CacheStoreSettings.ByteSizeOffset`). Tests that assert on `metadata.Size` must account for this offset.
+
+## CI/CD
+
+The project uses **GitHub Actions** (`.github/workflows/ci-release.yml`) for continuous integration and release publishing.
+
+### Pipeline Jobs
+
+| Job | Trigger | What it does |
+|-----|---------|--------------|
+| **CI** | Push to `main` | Build → test → pack with CalVer-preview → push to GitHub Packages |
+| **Release** | Manual approval (environment gate) | Rebuild without `-preview` → push to NuGet.org → create GitHub Release |
+
+### Versioning
+
+- Format: `yyyy.M.d.{run_number}` (CalVer). CI appends `-preview`.
+- `PACKAGE_VERSION` env var is set by the workflow; `Directory.Build.props` reads it.
+- Local builds produce `0.0.0-local` by default.
+
+### Secrets & Environments
+
+- `NUGET_API_KEY` repository secret for NuGet.org.
+- `NuGet-Release` environment with required reviewer gate for the Release job.
+- `GITHUB_TOKEN` (built-in) for GitHub Packages.
+
+### Legacy
+
+`Deploy/azure-pipelines.yml` is an Azure DevOps pipeline kept for reference. It is deprecated in favour of GitHub Actions.

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,0 +1,130 @@
+name: CI & Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+env:
+  DOTNET_VERSION: "10.x"
+  BUILD_CONFIG: Release
+
+jobs:
+  ci:
+    name: Build, Test & Publish Preview
+    runs-on: windows-latest
+    permissions:
+      contents: read
+      packages: write
+      checks: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Compute version
+        id: version
+        shell: pwsh
+        run: |
+          $now = Get-Date -AsUTC
+          $version = "$($now.Year).$($now.Month).$($now.Day).${{ github.run_number }}"
+          echo "RELEASE_VERSION=$version" >> $env:GITHUB_OUTPUT
+          echo "PREVIEW_VERSION=$version-preview" >> $env:GITHUB_OUTPUT
+          echo "Computed version: $version"
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration ${{ env.BUILD_CONFIG }} --no-restore
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.PREVIEW_VERSION }}
+
+      - name: Test
+        run: dotnet test --configuration ${{ env.BUILD_CONFIG }} --no-build --logger trx --collect:"XPlat Code Coverage" --results-directory ${{ runner.temp }}/TestResults
+
+      - name: Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Test Results
+          path: "${{ runner.temp }}/TestResults/**/*.trx"
+          reporter: dotnet-trx
+
+      - name: Pack (preview)
+        run: dotnet pack --configuration ${{ env.BUILD_CONFIG }} --no-build --output ${{ runner.temp }}/packages
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.PREVIEW_VERSION }}
+
+      - name: Push to GitHub Packages
+        run: |
+          dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name github --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
+          dotnet nuget push "${{ runner.temp }}/packages/*.nupkg" --source github --skip-duplicate
+        env:
+          DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER: 1
+
+      - name: Upload packages artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nupkg-preview
+          path: ${{ runner.temp }}/packages/*.nupkg
+          retention-days: 30
+
+    outputs:
+      release_version: ${{ steps.version.outputs.RELEASE_VERSION }}
+      preview_version: ${{ steps.version.outputs.PREVIEW_VERSION }}
+
+  release:
+    name: Publish to NuGet.org
+    needs: ci
+    runs-on: windows-latest
+    environment: NuGet-Release
+    permissions:
+      contents: write
+      packages: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration ${{ env.BUILD_CONFIG }} --no-restore
+        env:
+          PACKAGE_VERSION: ${{ needs.ci.outputs.release_version }}
+
+      - name: Pack (release)
+        run: dotnet pack --configuration ${{ env.BUILD_CONFIG }} --no-build --output ${{ runner.temp }}/packages
+        env:
+          PACKAGE_VERSION: ${{ needs.ci.outputs.release_version }}
+
+      - name: Push to NuGet.org
+        run: dotnet nuget push "${{ runner.temp }}/packages/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.ci.outputs.release_version }}
+          name: v${{ needs.ci.outputs.release_version }}
+          body: |
+            ## Packages
+
+            - `Ofn.ServiceFabric.Cache` v${{ needs.ci.outputs.release_version }}
+            - `Ofn.ServiceFabric.Cache.Client` v${{ needs.ci.outputs.release_version }}
+            - `Ofn.ServiceFabric.Cache.Abstractions` v${{ needs.ci.outputs.release_version }}
+
+            Published to [NuGet.org](https://www.nuget.org/profiles/esbenbach).
+          files: ${{ runner.temp }}/packages/*.nupkg
+          generate_release_notes: true

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -87,6 +87,7 @@ jobs:
     permissions:
       contents: write
       packages: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -110,8 +111,14 @@ jobs:
         env:
           PACKAGE_VERSION: ${{ needs.ci.outputs.release_version }}
 
+      - name: Authenticate with NuGet.org (Trusted Publishing)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: esbenbach
+
       - name: Push to NuGet.org
-        run: dotnet nuget push "${{ runner.temp }}/packages/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+        run: dotnet nuget push "${{ runner.temp }}/packages/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/Deploy/azure-pipelines.yml
+++ b/Deploy/azure-pipelines.yml
@@ -1,3 +1,6 @@
+# DEPRECATED: This pipeline has been superseded by GitHub Actions (.github/workflows/ci-release.yml).
+# It is kept here for reference during the transition period and can be removed once the migration is verified.
+
 name: $(Date:yyyy.M.d).$(Rev:r)
 
 trigger:

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -66,13 +66,25 @@ dotnet pack
 
 ## Configuration
 
-### Secrets (GitHub Settings → Secrets → Actions)
+### NuGet.org Trusted Publishing (OIDC)
 
-| Secret | Purpose |
-|--------|---------|
-| `NUGET_API_KEY` | API key for pushing to NuGet.org |
+This project uses **Trusted Publishing** to authenticate with NuGet.org — no long-lived API keys needed.
 
-`GITHUB_TOKEN` is provided automatically by GitHub Actions.
+How it works:
+1. The release job requests an OIDC token from GitHub.
+2. NuGet.org validates the token against a trusted publisher policy you configure.
+3. A short-lived (~1 hour) API key is issued for this workflow run only.
+4. Packages are pushed with that ephemeral key.
+
+**One-time setup on nuget.org:**
+1. Go to [nuget.org → Account → Trusted Publishing](https://www.nuget.org/account/trusted-publishers).
+2. Add a new trusted publisher with:
+   - **Repository Owner:** `esbenbach`
+   - **Repository:** `Ofn.ServiceFabric.Cache`
+   - **Workflow File:** `ci-release.yml`
+   - **Environment:** `NuGet-Release`
+
+No `NUGET_API_KEY` secret is required. `GITHUB_TOKEN` is provided automatically by GitHub Actions.
 
 ### Environment (GitHub Settings → Environments)
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -58,7 +58,7 @@ dotnet pack         # produces 0.0.0-local.nupkg
 
 To simulate a specific version locally:
 
-```sh
+```pwsh
 $env:PACKAGE_VERSION = "1.0.0-test"
 dotnet build
 dotnet pack

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,89 @@
+# Versioning & Release Flow
+
+## Version Scheme
+
+This project uses **Calendar Versioning (CalVer)** with the format:
+
+```
+yyyy.M.d.{run_number}
+```
+
+For example: `2026.5.25.42`
+
+- `yyyy` — full year
+- `M` — month (no leading zero)
+- `d` — day (no leading zero)
+- `run_number` — GitHub Actions workflow run number (monotonically increasing)
+
+Preview (pre-release) packages append `-preview`: `2026.5.25.42-preview`
+
+## How Packages Are Published
+
+### Automatic (on every push to `main`)
+
+1. GitHub Actions builds, tests, and packs the libraries.
+2. Packages are versioned as `yyyy.M.d.{run_number}-preview`.
+3. Preview packages are pushed to **GitHub Packages** (the repository's NuGet feed).
+
+These are pre-release packages — consumers won't get them unless they opt in.
+
+### Release (manual approval)
+
+1. Go to the [Actions tab](https://github.com/esbenbach/Ofn.ServiceFabric.Cache/actions) on GitHub.
+2. Find the workflow run you want to release (it corresponds to a specific commit on `main`).
+3. Click **Review deployments** on the "Publish to NuGet.org" job.
+4. Approve the deployment.
+5. The workflow rebuilds the same commit with the release version (no `-preview` suffix).
+6. Packages are pushed to **NuGet.org**.
+7. A **GitHub Release** is automatically created with the `.nupkg` files attached.
+
+No manual tagging, branching, or version entry is required.
+
+## Where Packages End Up
+
+| Package | Preview Feed | Release Feed |
+|---------|--------------|--------------|
+| `Ofn.ServiceFabric.Cache` | GitHub Packages | NuGet.org |
+| `Ofn.ServiceFabric.Cache.Client` | GitHub Packages | NuGet.org |
+| `Ofn.ServiceFabric.Cache.Abstractions` | GitHub Packages | NuGet.org |
+
+## Local Development
+
+When building locally without `PACKAGE_VERSION` set, packages are versioned `0.0.0-local`. This prevents accidentally publishing local builds.
+
+```sh
+dotnet build        # produces 0.0.0-local
+dotnet pack         # produces 0.0.0-local.nupkg
+```
+
+To simulate a specific version locally:
+
+```sh
+$env:PACKAGE_VERSION = "1.0.0-test"
+dotnet build
+dotnet pack
+```
+
+## Configuration
+
+### Secrets (GitHub Settings → Secrets → Actions)
+
+| Secret | Purpose |
+|--------|---------|
+| `NUGET_API_KEY` | API key for pushing to NuGet.org |
+
+`GITHUB_TOKEN` is provided automatically by GitHub Actions.
+
+### Environment (GitHub Settings → Environments)
+
+| Environment | Protection |
+|-------------|------------|
+| `NuGet-Release` | Required reviewer (you) — prevents accidental releases |
+
+## Pipeline File
+
+The workflow is defined in [`.github/workflows/ci-release.yml`](.github/workflows/ci-release.yml).
+
+## Legacy
+
+The Azure DevOps pipeline at [`Deploy/azure-pipelines.yml`](Deploy/azure-pipelines.yml) is deprecated and kept for reference only.


### PR DESCRIPTION
This pull request introduces a migration from Azure DevOps pipelines to GitHub Actions for CI/CD, updates documentation to reflect the new build and release process, and clarifies versioning and packaging conventions. It also deprecates the old Azure pipeline and adds details about how item size accounting works in the cache service.

**CI/CD Pipeline Migration and Documentation:**

* Added a new GitHub Actions workflow (`.github/workflows/ci-release.yml`) to handle build, test, packaging, preview publishing to GitHub Packages, and gated release publishing to NuGet.org with automatic GitHub Release creation.
* Added a new `VERSIONING.md` documenting the CalVer versioning scheme, automated release flow, package destinations, local development versioning, and trusted publishing to NuGet.org.
* Updated `.github/copilot-instructions.md` to describe the new CI/CD process, versioning, secrets, and environments, and clarified that `Directory.Build.props` now manages shared package metadata. Also documented item size accounting for cache items.
* Marked the Azure DevOps pipeline (`Deploy/azure-pipelines.yml`) as deprecated in favor of GitHub Actions, with a clear notice at the top of the file.