### PR TITLE
Fix GitHub Actions pipeline and improve test reliability

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -62,7 +62,7 @@ jobs:
         shell: pwsh
         run: |
           Get-ChildItem -Recurse -Path $env:TEST_DIR -Filter $env:TEST_PROJECT_FILTER | ForEach-Object {
-            dotnet test $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --logger trx --collect:"XPlat Code Coverage" --results-directory TestResults
+            dotnet test $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --no-restore --logger trx --collect:"XPlat Code Coverage" --results-directory TestResults
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           $outputDir = Join-Path $env:RUNNER_TEMP "packages"
           Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
-            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --output $outputDir
+            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --no-restore --output $outputDir
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
         env:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -61,9 +61,8 @@ jobs:
       - name: Test
         shell: pwsh
         run: |
-          $resultsDir = Join-Path $env:RUNNER_TEMP "TestResults"
           Get-ChildItem -Recurse -Path $env:TEST_DIR -Filter $env:TEST_PROJECT_FILTER | ForEach-Object {
-            dotnet test $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --logger trx --collect:"XPlat Code Coverage" --results-directory $resultsDir
+            dotnet test $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --logger trx --collect:"XPlat Code Coverage" --results-directory TestResults
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
@@ -72,7 +71,7 @@ jobs:
         if: always()
         with:
           name: Test Results
-          path: "${{ runner.temp }}/TestResults/**/*.trx"
+          path: "TestResults/**/*.trx"
           reporter: dotnet-trx
 
       - name: Pack (preview)
@@ -87,9 +86,11 @@ jobs:
           PACKAGE_VERSION: ${{ steps.version.outputs.PREVIEW_VERSION }}
 
       - name: Push to GitHub Packages
+        shell: pwsh
         run: |
+          $packagesDir = Join-Path $env:RUNNER_TEMP "packages"
           dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name github --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
-          dotnet nuget push "${{ runner.temp }}/packages/*.nupkg" --source github --skip-duplicate
+          dotnet nuget push "$packagesDir/*.nupkg" --source github --skip-duplicate
         env:
           DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER: 1
 
@@ -159,7 +160,10 @@ jobs:
           user: esbenbach
 
       - name: Push to NuGet.org
-        run: dotnet nuget push "${{ runner.temp }}/packages/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
+        shell: pwsh
+        run: |
+          $packagesDir = Join-Path $env:RUNNER_TEMP "packages"
+          dotnet nuget push "$packagesDir/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -8,6 +8,9 @@ on:
 env:
   DOTNET_VERSION: "10.x"
   BUILD_CONFIG: Release
+  PROJECT_FILTER: "Ofn.ServiceFabric.Cache*.csproj"
+  TEST_PROJECT_FILTER: "*.csproj"
+  TEST_DIR: "test"
 
 jobs:
   ci:
@@ -38,15 +41,30 @@ jobs:
           echo "Computed version: $version"
 
       - name: Restore
-        run: dotnet restore
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
+            dotnet restore $_.FullName
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
       - name: Build
-        run: dotnet build --configuration ${{ env.BUILD_CONFIG }} --no-restore
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
+            dotnet build $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-restore
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
         env:
           PACKAGE_VERSION: ${{ steps.version.outputs.PREVIEW_VERSION }}
 
       - name: Test
-        run: dotnet test --configuration ${{ env.BUILD_CONFIG }} --no-build --logger trx --collect:"XPlat Code Coverage" --results-directory ${{ runner.temp }}/TestResults
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -Path $env:TEST_DIR -Filter $env:TEST_PROJECT_FILTER | ForEach-Object {
+            dotnet test $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --logger trx --collect:"XPlat Code Coverage" --results-directory "${{ runner.temp }}/TestResults"
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
       - name: Publish test results
         uses: dorny/test-reporter@v3
@@ -57,7 +75,12 @@ jobs:
           reporter: dotnet-trx
 
       - name: Pack (preview)
-        run: dotnet pack --configuration ${{ env.BUILD_CONFIG }} --no-build --output ${{ runner.temp }}/packages
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
+            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --output "${{ runner.temp }}/packages"
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
         env:
           PACKAGE_VERSION: ${{ steps.version.outputs.PREVIEW_VERSION }}
 
@@ -99,15 +122,30 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Restore
-        run: dotnet restore
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
+            dotnet restore $_.FullName
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
       - name: Build
-        run: dotnet build --configuration ${{ env.BUILD_CONFIG }} --no-restore
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
+            dotnet build $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-restore
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
         env:
           PACKAGE_VERSION: ${{ needs.ci.outputs.release_version }}
 
       - name: Pack (release)
-        run: dotnet pack --configuration ${{ env.BUILD_CONFIG }} --no-build --output ${{ runner.temp }}/packages
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
+            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --output "${{ runner.temp }}/packages"
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
         env:
           PACKAGE_VERSION: ${{ needs.ci.outputs.release_version }}
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -90,7 +90,10 @@ jobs:
         run: |
           $packagesDir = Join-Path $env:RUNNER_TEMP "packages"
           dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name github --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
-          dotnet nuget push "$packagesDir/*.nupkg" --source github --skip-duplicate
+          Get-ChildItem $packagesDir -Filter "*.nupkg" | ForEach-Object {
+            dotnet nuget push $_.FullName --source github --skip-duplicate
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
         env:
           DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER: 1
 
@@ -163,7 +166,10 @@ jobs:
         shell: pwsh
         run: |
           $packagesDir = Join-Path $env:RUNNER_TEMP "packages"
-          dotnet nuget push "$packagesDir/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
+          Get-ChildItem $packagesDir -Filter "*.nupkg" | ForEach-Object {
+            dotnet nuget push $_.FullName --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -61,8 +61,9 @@ jobs:
       - name: Test
         shell: pwsh
         run: |
+          $resultsDir = Join-Path $env:RUNNER_TEMP "TestResults"
           Get-ChildItem -Recurse -Path $env:TEST_DIR -Filter $env:TEST_PROJECT_FILTER | ForEach-Object {
-            dotnet test $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --logger trx --collect:"XPlat Code Coverage" --results-directory "${{ runner.temp }}/TestResults"
+            dotnet test $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --logger trx --collect:"XPlat Code Coverage" --results-directory $resultsDir
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 
@@ -77,8 +78,9 @@ jobs:
       - name: Pack (preview)
         shell: pwsh
         run: |
+          $outputDir = Join-Path $env:RUNNER_TEMP "packages"
           Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
-            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --output "${{ runner.temp }}/packages"
+            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --output $outputDir
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
         env:
@@ -142,8 +144,9 @@ jobs:
       - name: Pack (release)
         shell: pwsh
         run: |
+          $outputDir = Join-Path $env:RUNNER_TEMP "packages"
           Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
-            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --output "${{ runner.temp }}/packages"
+            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --output $outputDir
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
         env:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -90,6 +90,7 @@ jobs:
         run: |
           $packagesDir = Join-Path $env:RUNNER_TEMP "packages"
           dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name github --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           Get-ChildItem $packagesDir -Filter "*.nupkg" | ForEach-Object {
             dotnet nuget push $_.FullName --source github --skip-duplicate
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           $outputDir = Join-Path $env:RUNNER_TEMP "packages"
           Get-ChildItem -Recurse -Filter $env:PROJECT_FILTER | ForEach-Object {
-            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --output $outputDir
+            dotnet pack $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --no-restore --output $outputDir
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
         env:

--- a/test/Ofn.ServiceFabric.Cache.UnitTests/CacheClientMetricsTest.cs
+++ b/test/Ofn.ServiceFabric.Cache.UnitTests/CacheClientMetricsTest.cs
@@ -16,6 +16,7 @@ using Xunit;
 /// Tests that <see cref="ServiceFabricDistributedCache"/> emits the expected
 /// System.Diagnostics.Metrics measurements for each client-side operation.
 /// </summary>
+[Collection("Metrics")]
 public class CacheClientMetricsTest
 {
     private static readonly Guid TestCacheStoreId = Guid.Parse("11111111-1111-1111-1111-111111111111");

--- a/test/Ofn.ServiceFabric.Cache.UnitTests/CacheMetricsTest.cs
+++ b/test/Ofn.ServiceFabric.Cache.UnitTests/CacheMetricsTest.cs
@@ -20,6 +20,7 @@ using Xunit;
 /// Tests that <see cref="BaseCacheStoreService"/> emits the expected
 /// System.Diagnostics.Metrics measurements for each cache operation.
 /// </summary>
+[Collection("Metrics")]
 public class CacheMetricsTest
 {
     // ──────────────────────────────────────────────────────────────────────────

--- a/test/Ofn.ServiceFabric.Cache.UnitTests/DistributedCacheStoreLocatorMetricsTest.cs
+++ b/test/Ofn.ServiceFabric.Cache.UnitTests/DistributedCacheStoreLocatorMetricsTest.cs
@@ -20,6 +20,7 @@ using Xunit;
 /// Tests that <see cref="DistributedCacheStoreLocator"/> emits the expected
 /// System.Diagnostics.Metrics measurements for service discovery and partition-list refresh.
 /// </summary>
+[Collection("Metrics")]
 public class DistributedCacheStoreLocatorMetricsTest
 {
     // ──────────────────────────────────────────────────────────────────────────

--- a/test/Ofn.ServiceFabric.Cache.UnitTests/ExpirationScanTest.cs
+++ b/test/Ofn.ServiceFabric.Cache.UnitTests/ExpirationScanTest.cs
@@ -17,6 +17,7 @@ using Xunit;
 /// <summary>
 /// Tests for <see cref="BaseCacheStoreService.RemoveExpiredCacheItemsAsync"/>.
 /// </summary>
+[Collection("Metrics")]
 public class ExpirationScanTest
 {
     // ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
This pull request makes several improvements to the CI/CD pipeline and test structure. The main focus is on enhancing the GitHub Actions workflow for .NET projects by making the build and packaging steps more robust and flexible, as well as improving test isolation. Below are the most important changes:

**CI/CD Pipeline Improvements:**

* Updated the `.github/workflows/ci-release.yml` workflow to use PowerShell (`pwsh`) scripts for restoring, building, testing, packing, and publishing .NET projects. This allows for more granular control by iterating over project files and handling errors per project, rather than running commands at the solution level. [[1]](diffhunk://#diff-42a22ead44f8caf1b1f3555b7f6d50edc89d0f4ebe837b593542de41b1fd2ca8L41-R96) [[2]](diffhunk://#diff-42a22ead44f8caf1b1f3555b7f6d50edc89d0f4ebe837b593542de41b1fd2ca8L102-R155) [[3]](diffhunk://#diff-42a22ead44f8caf1b1f3555b7f6d50edc89d0f4ebe837b593542de41b1fd2ca8L121-R172)
* Introduced new environment variables (`PROJECT_FILTER`, `TEST_PROJECT_FILTER`, `TEST_DIR`) to allow flexible selection of project files for restore, build, test, and pack steps.

**Test Improvements:**

* Added the `[Collection("Metrics")]` attribute to four unit test classes (`CacheClientMetricsTest`, `CacheMetricsTest`, `DistributedCacheStoreLocatorMetricsTest`, `ExpirationScanTest`) to ensure tests that use metrics are properly isolated and do not interfere with each other. [[1]](diffhunk://#diff-1ac9eca9bb156108e86744a34f6ec7e9a35849a0be44985448d84c89120fca51R19) [[2]](diffhunk://#diff-4d71dbc9ada601a31b40b36db43bc9f14931f60755bc6a8e0852f1110eed210dR23) [[3]](diffhunk://#diff-61051c755a193d29695b7cdf556cf5198363d7361ae3c15905dcb048c08eeaeeR23) [[4]](diffhunk://#diff-51e5098a0dee452d95c4b0a566eb2803c2e36704a0ee5d6446a370867f6a6f42R20)