### PR TITLE
Fixed an issue where startup was writing to the statemanager

### DIFF
--- a/.github/instructions/server-cache.instructions.md
+++ b/.github/instructions/server-cache.instructions.md
@@ -23,7 +23,7 @@ applyTo: "Ofn.ServiceFabric.Cache/**/*.cs"
 - The meter name is `"Ofn.ServiceFabric.Cache"`.
 - All metrics are tagged with `partition_id`. Use the cached `_partitionIdTag` string field, not `Partition.PartitionInfo.Id.ToString()`.
 - Observable gauges for size/limit are created in `OnOpenAsync`, not in the constructor.
-- Reliable Dictionaries (`_cacheStore`, `_cacheStoreMetadata`) are initialized in `OnChangeRoleAsync(Primary)`, NOT in `OnOpenAsync`. The state manager is not readable during `OpenAsync`; it becomes writable only after role assignment.
+- Reliable Dictionaries (`_cacheStore`, `_cacheStoreMetadata`) are initialized in `OnChangeRoleAsync(Primary)`, NOT in `OnOpenAsync`. The state manager is not writable during `OpenAsync`; it becomes writable only after role assignment.
 
 ## Performance conventions
 

--- a/.github/instructions/server-cache.instructions.md
+++ b/.github/instructions/server-cache.instructions.md
@@ -23,6 +23,7 @@ applyTo: "Ofn.ServiceFabric.Cache/**/*.cs"
 - The meter name is `"Ofn.ServiceFabric.Cache"`.
 - All metrics are tagged with `partition_id`. Use the cached `_partitionIdTag` string field, not `Partition.PartitionInfo.Id.ToString()`.
 - Observable gauges for size/limit are created in `OnOpenAsync`, not in the constructor.
+- Reliable Dictionaries (`_cacheStore`, `_cacheStoreMetadata`) are initialized in `OnChangeRoleAsync(Primary)`, NOT in `OnOpenAsync`. The state manager is not readable during `OpenAsync`; it becomes writable only after role assignment.
 
 ## Performance conventions
 

--- a/Ofn.ServiceFabric.Cache/BaseCacheStoreService.cs
+++ b/Ofn.ServiceFabric.Cache/BaseCacheStoreService.cs
@@ -133,6 +133,8 @@ public abstract class BaseCacheStoreService : StatefulService, ICacheStoreServic
 
         _partitionIdTag = Partition.PartitionInfo.Id.ToString();
 
+        _maxSizeBytesPerPartition = (this.settings.MaxCacheSize * BytesInMegabyte) / partitionCount;
+
         // Register observable gauges for this partition's size and size limit.
         // Each gauge reports a single Measurement tagged with the partition ID so that
         // multi-partition deployments can be aggregated or filtered in the metrics backend.
@@ -148,8 +150,6 @@ public abstract class BaseCacheStoreService : StatefulService, ICacheStoreServic
             "By",
             "Per-partition cache size limit");
 
-        _maxSizeBytesPerPartition = (this.settings.MaxCacheSize * BytesInMegabyte) / partitionCount;
-
         _getCallbacks    = BuildRetryCallbacksForOperation("get");
         _setCallbacks    = BuildRetryCallbacksForOperation("set");
         _removeCallbacks = BuildRetryCallbacksForOperation("remove");
@@ -163,24 +163,39 @@ public abstract class BaseCacheStoreService : StatefulService, ICacheStoreServic
     /// </summary>
     /// <param name="newRole">The new replica role.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-protected override async Task OnChangeRoleAsync(ReplicaRole newRole, CancellationToken cancellationToken)
-{
-    cancellationToken.ThrowIfCancellationRequested();
+protected override async Task OnChangeRoleAsync(ReplicaRole newRole, CancellationToken cancellationToken)
 
-    if (newRole == ReplicaRole.Primary)
-    {
-        _cacheStore = await StateManager.GetOrAddAsync<IReliableDictionary<string, CachedItem>>(CacheStoreConstants.CacheStoreName);
-        _cacheStoreMetadata = await StateManager.GetOrAddAsync<IReliableDictionary<string, CacheStoreMetadata>>(CacheStoreConstants.CacheStoreMetadataName);
+{
+
+    cancellationToken.ThrowIfCancellationRequested();
+
+
+    if (newRole == ReplicaRole.Primary)
+
+    {
+
+        _cacheStore = await StateManager.GetOrAddAsync<IReliableDictionary<string, CachedItem>>(CacheStoreConstants.CacheStoreName);
+
+        _cacheStoreMetadata = await StateManager.GetOrAddAsync<IReliableDictionary<string, CacheStoreMetadata>>(CacheStoreConstants.CacheStoreMetadataName);
+
     }
-    else
-    {
-        _cacheStore = null;
-        _cacheStoreMetadata = null;
-    }
+    else
 
-    await base.OnChangeRoleAsync(newRole, cancellationToken);
-}
-
+    {
+
+        _cacheStore = null;
+
+        _cacheStoreMetadata = null;
+
+    }
+
+
+    await base.OnChangeRoleAsync(newRole, cancellationToken);
+
+}
+
+
+
     /// <inheritdoc/>
     protected override Task OnCloseAsync(CancellationToken cancellationToken)
     {

--- a/Ofn.ServiceFabric.Cache/BaseCacheStoreService.cs
+++ b/Ofn.ServiceFabric.Cache/BaseCacheStoreService.cs
@@ -101,10 +101,10 @@ public abstract class BaseCacheStoreService : StatefulService, ICacheStoreServic
     }
 
     private IReliableDictionary<string, CachedItem> CacheStore =>
-        _cacheStore ?? throw new InvalidOperationException("Cache store has not been initialized. Ensure OnOpenAsync completes before processing requests.");
+        _cacheStore ?? throw new InvalidOperationException("Cache store has not been initialized. The replica must be promoted to Primary before processing requests.");
 
     private IReliableDictionary<string, CacheStoreMetadata> CacheStoreMetadataDict =>
-        _cacheStoreMetadata ?? throw new InvalidOperationException("Cache metadata store has not been initialized. Ensure OnOpenAsync completes before processing requests.");
+        _cacheStoreMetadata ?? throw new InvalidOperationException("Cache metadata store has not been initialized. The replica must be promoted to Primary before processing requests.");
 
     private static void ValidateSettings(CacheStoreSettings settings)
     {
@@ -120,7 +120,8 @@ public abstract class BaseCacheStoreService : StatefulService, ICacheStoreServic
 
     /// <summary>
     /// Registers the <c>CacheStore</c> service property, resolves the partition count,
-    /// initializes the Reliable Dictionaries, and sets up metrics gauges.
+    /// and sets up metrics gauges. Reliable Dictionaries are initialized in
+    /// <see cref="OnChangeRoleAsync"/> once the replica is promoted to Primary.
     /// </summary>
     /// <param name="openMode">Indicates whether the replica is being opened as a new or existing replica.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
@@ -129,8 +130,6 @@ public abstract class BaseCacheStoreService : StatefulService, ICacheStoreServic
         using var client = new FabricClient();
         await client.PropertyManager.PutPropertyAsync(serviceUri, CacheStoreProperty, CacheStorePropertyValue, TimeSpan.FromSeconds(30), cancellationToken);
         partitionCount = (await client.QueryManager.GetPartitionListAsync(serviceUri, null, TimeSpan.FromSeconds(30), cancellationToken)).Count;
-        _cacheStore = await StateManager.GetOrAddAsync<IReliableDictionary<string, CachedItem>>(CacheStoreConstants.CacheStoreName);
-        _cacheStoreMetadata = await StateManager.GetOrAddAsync<IReliableDictionary<string, CacheStoreMetadata>>(CacheStoreConstants.CacheStoreMetadataName);
 
         _partitionIdTag = Partition.PartitionInfo.Id.ToString();
 
@@ -155,6 +154,24 @@ public abstract class BaseCacheStoreService : StatefulService, ICacheStoreServic
         _setCallbacks    = BuildRetryCallbacksForOperation("set");
         _removeCallbacks = BuildRetryCallbacksForOperation("remove");
         _pruneCallbacks  = BuildRetryCallbacksForOperation("prune");
+    }
+
+    /// <summary>
+    /// Initializes the Reliable Dictionaries when the replica is promoted to Primary.
+    /// The state manager only becomes writable after role assignment; <see cref="OnOpenAsync"/>
+    /// cannot safely call <c>GetOrAddAsync</c>.
+    /// </summary>
+    /// <param name="newRole">The new replica role.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    protected override async Task OnChangeRoleAsync(ReplicaRole newRole, CancellationToken cancellationToken)
+    {
+        if (newRole == ReplicaRole.Primary)
+        {
+            _cacheStore = await StateManager.GetOrAddAsync<IReliableDictionary<string, CachedItem>>(CacheStoreConstants.CacheStoreName);
+            _cacheStoreMetadata = await StateManager.GetOrAddAsync<IReliableDictionary<string, CacheStoreMetadata>>(CacheStoreConstants.CacheStoreMetadataName);
+        }
+
+        await base.OnChangeRoleAsync(newRole, cancellationToken);
     }
 
     /// <inheritdoc/>

--- a/Ofn.ServiceFabric.Cache/BaseCacheStoreService.cs
+++ b/Ofn.ServiceFabric.Cache/BaseCacheStoreService.cs
@@ -163,17 +163,24 @@ public abstract class BaseCacheStoreService : StatefulService, ICacheStoreServic
     /// </summary>
     /// <param name="newRole">The new replica role.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
-    protected override async Task OnChangeRoleAsync(ReplicaRole newRole, CancellationToken cancellationToken)
-    {
-        if (newRole == ReplicaRole.Primary)
-        {
-            _cacheStore = await StateManager.GetOrAddAsync<IReliableDictionary<string, CachedItem>>(CacheStoreConstants.CacheStoreName);
-            _cacheStoreMetadata = await StateManager.GetOrAddAsync<IReliableDictionary<string, CacheStoreMetadata>>(CacheStoreConstants.CacheStoreMetadataName);
-        }
+protected override async Task OnChangeRoleAsync(ReplicaRole newRole, CancellationToken cancellationToken)
+{
+    cancellationToken.ThrowIfCancellationRequested();
 
-        await base.OnChangeRoleAsync(newRole, cancellationToken);
+    if (newRole == ReplicaRole.Primary)
+    {
+        _cacheStore = await StateManager.GetOrAddAsync<IReliableDictionary<string, CachedItem>>(CacheStoreConstants.CacheStoreName);
+        _cacheStoreMetadata = await StateManager.GetOrAddAsync<IReliableDictionary<string, CacheStoreMetadata>>(CacheStoreConstants.CacheStoreMetadataName);
     }
+    else
+    {
+        _cacheStore = null;
+        _cacheStoreMetadata = null;
+    }
 
+    await base.OnChangeRoleAsync(newRole, cancellationToken);
+}
+
     /// <inheritdoc/>
     protected override Task OnCloseAsync(CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Fixed an issue where during startup the application was writing to the statemanager before it was availble.
Moved the state handling to the "OnChangeRoleAsync" and guarded it by the primary role as only primaries recieves/should receive write operations.