### PR TITLE
Reduced dependency constraint on MS* packages and add PR trigger

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,9 @@ updates:
           - "minor"
           - "patch"
 
+    ignore:
+      - dependency-name: "Microsoft.Extensions.*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -3,6 +3,8 @@ name: CI & Release
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch: {}
 
 env:
@@ -112,6 +114,7 @@ jobs:
   release:
     name: Publish to NuGet.org
     needs: ci
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: windows-latest
     environment: NuGet-Release
     permissions:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -114,7 +114,7 @@ jobs:
   release:
     name: Publish to NuGet.org
     needs: ci
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: windows-latest
     environment: NuGet-Release
     permissions:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -64,7 +64,7 @@ jobs:
         shell: pwsh
         run: |
           Get-ChildItem -Recurse -Path $env:TEST_DIR -Filter $env:TEST_PROJECT_FILTER | ForEach-Object {
-            dotnet test $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --no-restore --logger trx --collect:"XPlat Code Coverage" --results-directory TestResults
+            dotnet test $_.FullName --configuration ${{ env.BUILD_CONFIG }} --no-build --no-restore --report-trx
             if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           }
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,12 +8,12 @@
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.4" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="[10.0.0,)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="[10.0.0,)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[10.0.0,)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="[10.0.0,)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="[10.0.0,)" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="[10.0.0,)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="8.6.239" />
     <PackageVersion Include="Microsoft.ServiceFabric.Actors" Version="8.6.239" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,12 +8,12 @@
     <PackageVersion Include="AutoFixture.AutoMoq" Version="4.18.1" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.4" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Microsoft.ServiceFabric.AspNetCore.Kestrel" Version="8.6.239" />
     <PackageVersion Include="Microsoft.ServiceFabric.Actors" Version="8.6.239" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Microsoft.ServiceFabric.Actors" Version="8.6.239" />
     <PackageVersion Include="Microsoft.ServiceFabric.Services" Version="8.6.239" />
     <PackageVersion Include="Microsoft.ServiceFabric.Services.Remoting" Version="8.6.239" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3" Version="4.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />

--- a/Ofn.ServiceFabric.Cache.slnx
+++ b/Ofn.ServiceFabric.Cache.slnx
@@ -15,6 +15,7 @@
     </Project>
   </Folder>
   <Folder Name="/Solution Items/">
+    <File Path=".github/dependabot.yml" />
     <File Path=".github/workflows/ci-release.yml" />
     <File Path="Deploy/Deploy-SFApp.ps1" />
     <File Path="Deploy/Package-SFApp.ps1" />

--- a/test/Ofn.ServiceFabric.Cache.UnitTests/Ofn.ServiceFabric.Cache.UnitTests.csproj
+++ b/test/Ofn.ServiceFabric.Cache.UnitTests/Ofn.ServiceFabric.Cache.UnitTests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="AutoFixture.AutoMoq" />
     <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">


### PR DESCRIPTION
Bumped the dependencies for MS.* to 10.0.0 and added a PR trigger to the GH workflow.